### PR TITLE
Fix dtype checks in zmoments to_complex and to_real

### DIFF
--- a/mtflearn/features/_zmoments.py
+++ b/mtflearn/features/_zmoments.py
@@ -298,7 +298,7 @@ class zmoments:
         return np.iscomplexobj(self.data)
 
     def to_complex(self):
-        if self.data.dtype != complex:
+        if not self.is_complex:
             c_matrix = construct_complex_matrix(n=self.n, m=self.m)
             if self.data.ndim == 2:
                 # zm_complex = c_matrix.dot((self.data).T).T
@@ -324,7 +324,7 @@ class zmoments:
         zmoments
             Zernike moments in real representation.
         """
-        if self.data.dtype == complex:
+        if self.is_complex:
             # Get inverse transformation matrix
             inv_matrix, n_real, m_real = construct_real_matrix(self.n, self.m)
 


### PR DESCRIPTION
## Summary
- `to_complex` and `to_real` used bare `dtype == complex` / `dtype != complex` checks, which only match `np.complex128` (Python's built-in `complex`)
- `np.complex64` was not recognised as complex, causing `to_complex` to run an unnecessary complex-to-complex conversion and `to_real` to skip conversion entirely and return `self` unchanged
- Fixed by replacing both checks with `self.is_complex` (`np.iscomplexobj`), which correctly handles all complex dtypes

## Test plan
- [ ] Verify `to_complex` returns `self` unchanged for `np.complex64` input
- [ ] Verify `to_real` correctly converts `np.complex64` input to real representation
- [ ] Run existing test suite: `pytest tests/`

Generated with [Claude Code](https://claude.com/claude-code)