### PR TITLE
Fix valid_mask negative-zero indexing and mirror_map redundant to_complex calls

### DIFF
--- a/mtflearn/features/_zmoments.py
+++ b/mtflearn/features/_zmoments.py
@@ -286,9 +286,10 @@ class zmoments:
             edge_after = self.patch_size - 1 - edge_before
 
             valid_mask[:edge_before, :] = False           # top edge
-            valid_mask[-edge_after:, :] = False           # bottom edge
             valid_mask[:, :edge_before] = False           # left edge
-            valid_mask[:, -edge_after:] = False           # right edges
+            if edge_after > 0:
+                valid_mask[-edge_after:, :] = False       # bottom edge
+                valid_mask[:, -edge_after:] = False       # right edge
             return valid_mask
         else:
             raise ValueError("Data must be 2D or 3D array.")
@@ -469,8 +470,9 @@ class zmoments:
         else:
             zm = self.unselect(m_unselect=m_unselect).normalize(order=p)
 
-        A = zm.to_complex().data.real
-        B = zm.to_complex().data.imag
+        zm_c = zm.to_complex()
+        A = zm_c.data.real
+        B = zm_c.data.imag
         part1 = A ** 2 - B ** 2
         part2 = 2 * A * B
 
@@ -482,7 +484,7 @@ class zmoments:
             data = np.vstack([part1, part2])  # (2*num_moments, height, width)
 
         # Notice
-        ms = zm.to_complex().m
+        ms = zm_c.m
         cosmt = np.array([np.cos(m * t) for t in theta for m in ms]).reshape(len(theta), -1)
         sinmt = np.array([np.sin(m * t) for t in theta for m in ms]).reshape(len(theta), -1)
         matrix = np.hstack([cosmt, sinmt])  # 360 x N


### PR DESCRIPTION
## Summary
- **`valid_mask`**: When `patch_size=1`, `edge_after=0` causes `valid_mask[-0:, :]` to be interpreted as `valid_mask[0:, :]`, incorrectly setting the entire mask to `False`. Fixed by guarding the bottom/right edge assignments with `if edge_after > 0`
- **`mirror_map`**: `to_complex()` was called 3 times redundantly on the same object. Cached the result in `zm_c` to avoid recomputing the full complex transformation matrix and dot product twice

## Notes
- Both fixes are behaviour-preserving for all realistic inputs (`patch_size > 1`)
- All 13 existing tests pass

## Test plan
- [x] `pytest tests/features/test_zmoments.py` — all 13 tests pass

Generated with [Claude Code](https://claude.com/claude-code)